### PR TITLE
adding queueSize to support bounded queue -

### DIFF
--- a/memq-dw-bundle/src/main/java/io/appform/ExecutorServiceProvider.java
+++ b/memq-dw-bundle/src/main/java/io/appform/ExecutorServiceProvider.java
@@ -4,6 +4,6 @@ import java.util.concurrent.ExecutorService;
 
 public interface ExecutorServiceProvider {
 
-    ExecutorService threadPool(String name, int parallel);
+    ExecutorService threadPool(String name, int parallel, int queueSize);
 
 }

--- a/memq-dw-bundle/src/main/java/io/appform/config/ExecutorConfig.java
+++ b/memq-dw-bundle/src/main/java/io/appform/config/ExecutorConfig.java
@@ -1,6 +1,7 @@
 package io.appform.config;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
 import javax.validation.constraints.Max;
@@ -21,4 +22,5 @@ public class ExecutorConfig {
     @Max(300)
     int threadPoolSize;
 
+    int queueSize;
 }

--- a/memq-dw-bundle/src/test/java/io/appform/MemqActorBundleTest.java
+++ b/memq-dw-bundle/src/test/java/io/appform/MemqActorBundleTest.java
@@ -12,7 +12,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import lombok.Getter;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -25,18 +24,6 @@ import static org.mockito.Mockito.when;
 class MemqActorBundleTest {
 
     private static final String GLOBAL_THREADPOOL_NAME = "GLOBAL";
-
-    static class TestConfig extends Configuration {
-        @Getter
-        private MemqConfig memqConfig = MemqConfig.builder()
-                .executors(List.of(ExecutorConfig.builder()
-                        .threadPoolSize(Constants.DEFAULT_THREADPOOL)
-                        .name(GLOBAL_THREADPOOL_NAME)
-                        .build()))
-                .build();
-
-    }
-
     final TestConfig testConfig = new TestConfig();
     HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
     JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
@@ -63,11 +50,22 @@ class MemqActorBundleTest {
 
                 @Override
                 protected ExecutorServiceProvider executorServiceProvider(TestConfig testConfig) {
-                    return (name, parallel) -> Executors.newFixedThreadPool(Constants.DEFAULT_THREADPOOL);
+                    return (name, parallel, queueSize) -> Executors.newFixedThreadPool(Constants.DEFAULT_THREADPOOL);
                 }
             };
             bundle.initialize(bootstrap);
             bundle.run(testConfig, environment);
         });
+    }
+
+    static class TestConfig extends Configuration {
+        @Getter
+        private MemqConfig memqConfig = MemqConfig.builder()
+                .executors(List.of(ExecutorConfig.builder()
+                        .threadPoolSize(Constants.DEFAULT_THREADPOOL)
+                        .name(GLOBAL_THREADPOOL_NAME)
+                        .build()))
+                .build();
+
     }
 }

--- a/memq-dw-bundle/src/test/java/io/appform/MemqActorSystemTest.java
+++ b/memq-dw-bundle/src/test/java/io/appform/MemqActorSystemTest.java
@@ -8,7 +8,6 @@ import io.appform.memq.actor.HighLevelActorConfig;
 import io.appform.memq.actor.Message;
 import io.appform.memq.retry.config.NoRetryConfig;
 import lombok.val;
-import org.apache.commons.lang3.builder.ToStringExclude;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -23,21 +22,6 @@ class MemqActorSystemTest {
     private static final String GLOBAL_THREADPOOL_NAME = "GLOBAL";
     private static final int SINGLE_PARTITION = 1;
 
-    enum ActorType {
-        TEST_HIGH_LEVEL_ACTOR,
-        ;
-    }
-
-    static class TestMessage implements Message {
-
-        String value = UUID.randomUUID().toString();
-
-        @Override
-        public String id() {
-            return value;
-        }
-    }
-
     @Test
     void newActorRegisterAndCloseTest() {
         assertDoesNotThrow(() -> {
@@ -49,7 +33,7 @@ class MemqActorSystemTest {
                             .build()))
                     .build();
             val memqActorSystem = new MemqActorSystem(memqConfig,
-                    (name, parallel) -> Executors.newFixedThreadPool(Constants.DEFAULT_THREADPOOL),
+                    (name, parallel, queueSize) -> Executors.newFixedThreadPool(Constants.DEFAULT_THREADPOOL),
                     metricRegistry);
             val highLevelActorConfig = HighLevelActorConfig.builder()
                     .partitions(SINGLE_PARTITION)
@@ -65,5 +49,19 @@ class MemqActorSystemTest {
             assertNotNull(highLevelActor);
             memqActorSystem.close();
         });
+    }
+
+    enum ActorType {
+        TEST_HIGH_LEVEL_ACTOR,
+    }
+
+    static class TestMessage implements Message {
+
+        String value = UUID.randomUUID().toString();
+
+        @Override
+        public String id() {
+            return value;
+        }
     }
 }


### PR DESCRIPTION
While creating ExecutorService using ThreadPoolExecutor we are providing LinkedBlockingQueue without any limit. Queue limit is Integer.MAX_VALUE. Once a given queue size has reached RejectedExecutionHandler is used to handle exceptions or raise events.

Adding support to provide bounded queue size via config.