### PR TITLE
Concurrency per partition

### DIFF
--- a/memq-actor/pom.xml
+++ b/memq-actor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.appform.memq</groupId>
         <artifactId>memq</artifactId>
-        <version>0.1.2</version>
+        <version>0.1.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/memq-actor/src/main/java/io/appform/memq/HighLevelActor.java
+++ b/memq-actor/src/main/java/io/appform/memq/HighLevelActor.java
@@ -58,6 +58,7 @@ public abstract class HighLevelActor<MessageType extends Enum<MessageType>, M ex
                 actorSystem.createRetryer(highLevelActorConfig),
                 highLevelActorConfig.getPartitions(),
                 highLevelActorConfig.getMaxSizePerPartition(),
+                highLevelActorConfig.getMaxConcurrencyPerPartition(),
                 actorSystem.partitioner(highLevelActorConfig, partitioner),
                 actorSystem.observers(type.name(), highLevelActorConfig, observers));
         actorSystem.register(actor);
@@ -75,6 +76,10 @@ public abstract class HighLevelActor<MessageType extends Enum<MessageType>, M ex
 
     public final long size() {
         return actor.size();
+    }
+
+    public final long inFlight() {
+        return actor.inFlight();
     }
 
     public final boolean isEmpty() {

--- a/memq-actor/src/main/java/io/appform/memq/HighLevelActorConfig.java
+++ b/memq-actor/src/main/java/io/appform/memq/HighLevelActorConfig.java
@@ -30,7 +30,7 @@ public class HighLevelActorConfig {
 
     @Min(1)
     @Builder.Default
-    long maxConcurrencyPerPartition = Long.MAX_VALUE;
+    int maxConcurrencyPerPartition = Integer.MAX_VALUE;
 
     @Valid
     @NotNull

--- a/memq-actor/src/main/java/io/appform/memq/HighLevelActorConfig.java
+++ b/memq-actor/src/main/java/io/appform/memq/HighLevelActorConfig.java
@@ -28,6 +28,10 @@ public class HighLevelActorConfig {
     @Builder.Default
     long maxSizePerPartition = Long.MAX_VALUE;
 
+    @Min(1)
+    @Builder.Default
+    long maxConcurrencyPerPartition = Long.MAX_VALUE;
+
     @Valid
     @NotNull
     @Builder.Default

--- a/memq-actor/src/main/java/io/appform/memq/actor/Actor.java
+++ b/memq-actor/src/main/java/io/appform/memq/actor/Actor.java
@@ -248,7 +248,8 @@ public class Actor<M extends Message> implements AutoCloseable {
                         return;
                     }
                     //Find new messages
-                    val newInOrderedMessages = messages.keySet().stream()
+                    val newInOrderedMessages = messages.keySet()
+                            .stream()
                             .limit(this.maxConcurrency)
                             .collect(Collectors.toSet());
                     val newMessageIds = Set.copyOf(Sets.difference(newInOrderedMessages, inFlight));

--- a/memq-actor/src/main/java/io/appform/memq/actor/Actor.java
+++ b/memq-actor/src/main/java/io/appform/memq/actor/Actor.java
@@ -54,7 +54,7 @@ public class Actor<M extends Message> implements AutoCloseable {
             RetryStrategy retryer,
             int partitions,
             long maxSizePerPartition,
-            long maxConcurrencyPerPartition,
+            int maxConcurrencyPerPartition,
             ToIntFunction<M> partitioner,
             List<ActorObserver> observers) {
         Objects.requireNonNull(name, "Name cannot be null");
@@ -146,7 +146,7 @@ public class Actor<M extends Message> implements AutoCloseable {
         private final Actor<M> actor;
         private final String name;
         private final long maxSize;
-        private final long maxConcurrency;
+        private final int maxConcurrency;
         private final ReentrantLock lock = new ReentrantLock();
         private final Condition checkCondition = lock.newCondition();
         private final Map<String, InternalMessage<M>> messages = new LinkedHashMap<>();
@@ -154,7 +154,7 @@ public class Actor<M extends Message> implements AutoCloseable {
         private final AtomicBoolean stopped = new AtomicBoolean();
         private Future<?> monitorFuture;
 
-        public Mailbox(Actor<M> actor, int partition, long maxSize, long maxConcurrency) {
+        public Mailbox(Actor<M> actor, int partition, long maxSize, int maxConcurrency) {
             this.actor = actor;
             this.maxSize = maxSize;
             this.maxConcurrency = maxConcurrency;
@@ -181,7 +181,7 @@ public class Actor<M extends Message> implements AutoCloseable {
         }
 
 
-        public final long inFlight() {
+        public final int inFlight() {
             lock.lock();
             try {
                 return inFlight.size();

--- a/memq-actor/src/main/java/io/appform/memq/stats/ActorMetricObserver.java
+++ b/memq-actor/src/main/java/io/appform/memq/stats/ActorMetricObserver.java
@@ -49,6 +49,14 @@ public class ActorMetricObserver extends ActorObserver {
                                                   return actor.size();
                                               }
                                           });
+        this.metricRegistry.gauge(MetricRegistry.name(getMetricPrefix(actorName), "in_flight"),
+                (MetricRegistry.MetricSupplier<Gauge<Long>>) () ->
+                        new CachedGauge<>(5, TimeUnit.SECONDS) {
+                            @Override
+                            protected Long loadValue() {
+                                return actor.inFlight();
+                            }
+                        });
     }
 
     @Override

--- a/memq-actor/src/test/java/io/appform/memq/ActorConcurrencyTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/ActorConcurrencyTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/memq-actor/src/test/java/io/appform/memq/ActorConcurrencyTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/ActorConcurrencyTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.Duration;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -26,7 +27,7 @@ public class ActorConcurrencyTest {
 
     @Test
     public void testMaxConcurrency(ActorSystem actorSystem) {
-        val concurrency = new Random().nextInt(1,5);
+        val concurrency = ThreadLocalRandom.current().nextInt(1, 5);
         val metricPrefix = "actor." + TestUtil.HighLevelActorType.BLOCKING_ACTOR.name() + ".";
         val counter = new AtomicInteger();
         val sideline = new AtomicBoolean();

--- a/memq-actor/src/test/java/io/appform/memq/ActorConcurrencyTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/ActorConcurrencyTest.java
@@ -1,0 +1,50 @@
+package io.appform.memq;
+
+import com.codahale.metrics.Meter;
+import io.appform.memq.actor.ActorOperation;
+import io.appform.memq.helper.TestUtil;
+import io.appform.memq.helper.message.TestIntMessage;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+@ExtendWith(MemQTestExtension.class)
+public class ActorConcurrencyTest {
+
+    @Test
+    public void testMaxConcurrency(ActorSystem actorSystem) {
+        val concurrency = new Random().nextInt(1,5);
+        val metricPrefix = "actor." + TestUtil.HighLevelActorType.BLOCKING_ACTOR.name() + ".";
+        val counter = new AtomicInteger();
+        val sideline = new AtomicBoolean();
+        val blockConsume = new AtomicBoolean(true);
+        val actorConfig = TestUtil.noRetryActorConfig(Constants.SINGLE_PARTITION, false,  Long.MAX_VALUE, concurrency);
+        val actor = TestUtil.blockingActor(counter, sideline, blockConsume,
+                actorConfig, actorSystem, List.of());
+        IntStream.range(0, 10).boxed().forEach(i -> {
+            val publish = actor.publish(new TestIntMessage(i));
+            assertTrue(publish);
+        });
+        assertEquals(concurrency, actor.inFlight());
+        blockConsume.set(false);
+        Awaitility.await()
+                .timeout(Duration.ofMinutes(1))
+                .catchUncaughtExceptions()
+                .until(actor::isEmpty);
+        val metrics = actorSystem.metricRegistry().getMetrics();
+        assertEquals(10, ((Meter) metrics.get(metricPrefix + ActorOperation.PUBLISH.name() + ".total")).getCount());
+    }
+}

--- a/memq-actor/src/test/java/io/appform/memq/HighLevelActorTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/HighLevelActorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/memq-actor/src/test/java/io/appform/memq/HighLevelActorTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/HighLevelActorTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/memq-actor/src/test/java/io/appform/memq/actor/ActorTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/actor/ActorTest.java
@@ -79,7 +79,7 @@ class ActorTest {
                 new NoRetryStrategy(new NoRetryConfig()),
                 partition,
                 Long.MAX_VALUE,
-                Long.MAX_VALUE,
+                Integer.MAX_VALUE,
                 message -> Math.absExact(message.id().hashCode()) % partition,
                 new ArrayList<>());
     }

--- a/memq-actor/src/test/java/io/appform/memq/actor/ActorTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/actor/ActorTest.java
@@ -79,6 +79,7 @@ class ActorTest {
                 new NoRetryStrategy(new NoRetryConfig()),
                 partition,
                 Long.MAX_VALUE,
+                Long.MAX_VALUE,
                 message -> Math.absExact(message.id().hashCode()) % partition,
                 new ArrayList<>());
     }

--- a/memq-actor/src/test/java/io/appform/memq/helper/TestUtil.java
+++ b/memq-actor/src/test/java/io/appform/memq/helper/TestUtil.java
@@ -143,19 +143,19 @@ public class TestUtil {
     public static HighLevelActorConfig noRetryActorConfig(int partition,
                                                           boolean metricDisabled,
                                                           ExceptionHandlerConfig exceptionHandlerConfig) {
-        return noRetryActorConfig(partition, metricDisabled, exceptionHandlerConfig, Long.MAX_VALUE, Long.MAX_VALUE);
+        return noRetryActorConfig(partition, metricDisabled, exceptionHandlerConfig, Long.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     public static HighLevelActorConfig noRetryActorConfig(int partition,
                                                           boolean metricDisabled,
                                                           long maxSizePerPartition) {
-        return noRetryActorConfig(partition, metricDisabled, new SidelineConfig(), maxSizePerPartition, Long.MAX_VALUE);
+        return noRetryActorConfig(partition, metricDisabled, new SidelineConfig(), maxSizePerPartition, Integer.MAX_VALUE);
     }
 
     public static HighLevelActorConfig noRetryActorConfig(int partition,
                                                           boolean metricDisabled,
                                                           long maxSizePerPartition,
-                                                          long maxConcurrencyPerPartition) {
+                                                          int maxConcurrencyPerPartition) {
         return noRetryActorConfig(partition, metricDisabled, new SidelineConfig(), maxSizePerPartition, maxConcurrencyPerPartition);
     }
 
@@ -163,7 +163,7 @@ public class TestUtil {
                                                           boolean metricDisabled,
                                                           ExceptionHandlerConfig exceptionHandlerConfig,
                                                           long maxSizePerPartition,
-                                                          long maxConcurrencyPerPartition) {
+                                                          int maxConcurrencyPerPartition) {
         return HighLevelActorConfig.builder()
                 .partitions(partition)
                 .maxSizePerPartition(maxSizePerPartition)

--- a/memq-actor/src/test/java/io/appform/memq/helper/TestUtil.java
+++ b/memq-actor/src/test/java/io/appform/memq/helper/TestUtil.java
@@ -143,25 +143,34 @@ public class TestUtil {
     public static HighLevelActorConfig noRetryActorConfig(int partition,
                                                           boolean metricDisabled,
                                                           ExceptionHandlerConfig exceptionHandlerConfig) {
-        return noRetryActorConfig(partition, metricDisabled, exceptionHandlerConfig, Long.MAX_VALUE);
+        return noRetryActorConfig(partition, metricDisabled, exceptionHandlerConfig, Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
     public static HighLevelActorConfig noRetryActorConfig(int partition,
                                                           boolean metricDisabled,
                                                           long maxSizePerPartition) {
-        return noRetryActorConfig(partition, metricDisabled, new SidelineConfig(), maxSizePerPartition);
+        return noRetryActorConfig(partition, metricDisabled, new SidelineConfig(), maxSizePerPartition, Long.MAX_VALUE);
+    }
+
+    public static HighLevelActorConfig noRetryActorConfig(int partition,
+                                                          boolean metricDisabled,
+                                                          long maxSizePerPartition,
+                                                          long maxConcurrencyPerPartition) {
+        return noRetryActorConfig(partition, metricDisabled, new SidelineConfig(), maxSizePerPartition, maxConcurrencyPerPartition);
     }
 
     public static HighLevelActorConfig noRetryActorConfig(int partition,
                                                           boolean metricDisabled,
                                                           ExceptionHandlerConfig exceptionHandlerConfig,
-                                                          long maxSizePerPartition) {
+                                                          long maxSizePerPartition,
+                                                          long maxConcurrencyPerPartition) {
         return HighLevelActorConfig.builder()
                 .partitions(partition)
                 .maxSizePerPartition(maxSizePerPartition)
                 .retryConfig(new NoRetryConfig())
                 .executorName(GLOBAL_EXECUTOR_SERVICE_GROUP)
                 .metricDisabled(metricDisabled)
+                .maxConcurrencyPerPartition(maxConcurrencyPerPartition)
                 .exceptionHandlerConfig(exceptionHandlerConfig)
                 .build();
     }

--- a/memq-actor/src/test/java/io/appform/memq/observer/MetricObserverActorTest.java
+++ b/memq-actor/src/test/java/io/appform/memq/observer/MetricObserverActorTest.java
@@ -41,7 +41,7 @@ class MetricObserverActorTest {
                 .catchUncaughtExceptions()
                 .until(actor::isEmpty); //Wait until all messages are processed
         val metrics = actorSystem.metricRegistry().getMetrics();
-        assertEquals(17, metrics.size());
+        assertEquals(18, metrics.size());
         assertEquals(1, ((Meter) metrics.get(metricPrefix + ActorOperation.PUBLISH.name() + totalPostfix)).getCount());
         assertEquals(1, ((Meter) metrics.get(metricPrefix + ActorOperation.PUBLISH.name() + successPostfix)).getCount());
         assertEquals(0, ((Meter) metrics.get(metricPrefix + ActorOperation.PUBLISH.name() + failedPostfix)).getCount());

--- a/memq-dw-bundle/pom.xml
+++ b/memq-dw-bundle/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.appform.memq</groupId>
         <artifactId>memq</artifactId>
-        <version>0.1.2</version>
+        <version>0.1.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>memq-dw-bundle</artifactId>
-    <version>2.1.10-0-3</version>
+    <version>2.1.10-0-4</version>
     <properties>
         <dropwizard.version>2.1.10</dropwizard.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.memq</groupId>
     <artifactId>memq</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <name>Mem Q Actors</name>
     <url>https://github.com/appform-io/memq</url>
     <description>In memory partitioned actor system</description>


### PR DESCRIPTION
Added max concurrency per partition. This will prevent bombarding of shared threadpool across queues
